### PR TITLE
Script to manually publish docs to staging d.r.c.

### DIFF
--- a/script/publish-docs
+++ b/script/publish-docs
@@ -4,6 +4,24 @@ set -euo pipefail
 
 ROOT=$(cd $(dirname $0)/.. && pwd)
 
+TARGET=${1:-staging}
+
+case "${TARGET}" in
+  staging)
+    CONTENT_STORE_URL=http://staging.developer.rackspace.com:8000
+    ;;
+  production)
+    CONTENT_STORE_URL=https://developer.rackspace.com
+    ;;
+  http*)
+    CONTENT_STORE_URL=${TARGET}
+    ;;
+  *)
+    echo "Usage: ${0} <environment|http://...>"
+    exit 1
+    ;;
+esac
+
 [ -z "${CONTENT_STORE_APIKEY:-}" ] && {
   echo "No API key set!" >&2
   echo "export CONTENT_STORE_APIKEY=\"...\""
@@ -11,7 +29,7 @@ ROOT=$(cd $(dirname $0)/.. && pwd)
 }
 
 exec docker run --rm \
-  -e CONTENT_STORE_URL=http://staging.developer.rackspace.com:8000 \
+  -e CONTENT_STORE_URL=${CONTENT_STORE_URL} \
   -e CONTENT_STORE_APIKEY=${CONTENT_STORE_APIKEY} \
   -e CONTENT_ID_BASE=https://github.com/rackspace/rack \
   -e TRAVIS_PULL_REQUEST="false" \

--- a/script/publish-docs
+++ b/script/publish-docs
@@ -11,7 +11,7 @@ case "${TARGET}" in
     CONTENT_STORE_URL=http://staging.developer.rackspace.com:8000
     ;;
   production)
-    CONTENT_STORE_URL=https://developer.rackspace.com
+    CONTENT_STORE_URL=https://developer.rackspace.com:9000
     ;;
   http*)
     CONTENT_STORE_URL=${TARGET}

--- a/script/publish-docs
+++ b/script/publish-docs
@@ -28,10 +28,11 @@ esac
   exit 1
 }
 
+echo "Submitting metadata envelopes to ${CONTENT_STORE_URL}."
+
 exec docker run --rm \
   -e CONTENT_STORE_URL=${CONTENT_STORE_URL} \
   -e CONTENT_STORE_APIKEY=${CONTENT_STORE_APIKEY} \
-  -e CONTENT_ID_BASE=https://github.com/rackspace/rack \
   -e TRAVIS_PULL_REQUEST="false" \
   -v ${ROOT}/docs:/usr/control-repo \
   quay.io/deconst/preparer-sphinx

--- a/script/publish-staging-docs
+++ b/script/publish-staging-docs
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT=$(cd $(dirname $0)/.. && pwd)
+
+[ -z "${CONTENT_STORE_APIKEY:-}" ] && {
+  echo "No API key set!" >&2
+  echo "export CONTENT_STORE_APIKEY=\"...\""
+  exit 1
+}
+
+exec docker run --rm \
+  -e CONTENT_STORE_URL=http://staging.developer.rackspace.com:8000 \
+  -e CONTENT_STORE_APIKEY=${CONTENT_STORE_APIKEY} \
+  -e CONTENT_ID_BASE=https://github.com/rackspace/rack \
+  -e TRAVIS_PULL_REQUEST="false" \
+  -v ${ROOT}/docs:/usr/control-repo \
+  quay.io/deconst/preparer-sphinx


### PR DESCRIPTION
If you have:

 * Docker installed and running
 * The `CONTENT_STORE_APIKEY` set

Running `script/publish-staging-docs` will publish the documentation to:

[http://staging.developer.rackspace.com/docs/user-guides/rack-cli/](http://staging.developer.rackspace.com/docs/user-guides/rack-cli/#)