### PR TITLE
Format the docs to work with the DRC-style ToC

### DIFF
--- a/docs/_toc.rst
+++ b/docs/_toc.rst
@@ -1,0 +1,7 @@
+.. toctree::
+   :maxdepth: 99
+   :includehidden:
+
+   configuration.rst
+   globaloptions.rst
+   services/index.rst

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -4,10 +4,10 @@ Installation and Configuration
 ==============================
 
 .. warning::
-   The installation / configuration instructions here must be
+   The installation/configuration instructions here must be
    considered buyer-beware. As development continues, a range of configuration
-   options will be supported; as such what works today may not work tomorrow,
-   but it works right now so that's ok.
+   options will be supported; what works today may not work tomorrow, but it
+   works right now so that's ok.
 
 Installation
 ------------
@@ -64,17 +64,17 @@ The following commands will set up Rackspace CLI. First, open Powershell_ise and
 
   #requires -Version 3
   $DownloadPath = 'C:\Tools'
-  
+
   Write-Output -InputObject "[$(Get-Date)] Status  :: Set the Tools Directory $DownloadPath"
   New-Item -Path $DownloadPath -ItemType Directory -ErrorAction SilentlyContinue > $null
   Set-Location -Path $DownloadPath -ErrorAction SilentlyContinue
-  
+
   Write-Output -InputObject "[$(Get-Date)] Status  :: Download Rackspace CLI in C:\Tools"
   Invoke-WebRequest -Uri 'https://goo.gl/NMvmcx/Windows/amd64/rack.exe' -Method Get -OutFile rack.exe
-  
+
   Write-Output -InputObject "[$(Get-Date)] Status  :: Unblock the executable file rack.exe"
   Unblock-File -Path $("$DownloadPath\rack.exe")
-  
+
   Write-Output -InputObject "[$(Get-Date)] Status  :: Permanently set the path $DownloadPath to the Environment variable (Reboot required)."
   [System.Environment]::SetEnvironmentVariable('Path', $env:Path + 'C:\Tools', [System.EnvironmentVariableTarget]::Machine)
   Write-Output -InputObject "[$(Get-Date)] Status  :: Temporarily set the path $DownloadPath to the Environment variable for immediate use in the current powershell session"
@@ -103,9 +103,7 @@ run the interactive ``configure`` command.
    Windows users should use PowerShell, not PowerShell ISE to run this
    command.
 
-    rack configure
-
-This command will automatically create a configuration file for you if it
+``configure`` will automatically create a configuration file for you if it
 doesn't exist and walk you through creating a profile for it::
 
     rack configure
@@ -153,6 +151,8 @@ The config file format is like the following::
     api-key=<another rackspace api key>
 
 In the example above there is a default profile that doesn't have a named section. "another-profile" is a different profile in the config file. When using the default profile, you don't need to supply a flag when executing ``rack``. A specific profile can be specified on the command-line with the ``profile`` flag.
+
+::
 
     rack --profile another-profile servers instance list
 

--- a/docs/globaloptions.rst
+++ b/docs/globaloptions.rst
@@ -22,20 +22,20 @@ Options
 ``--output``
 ~~~~~~~~~~~~
 
-  (string) The format in which to return the output. Options are: table, json, csv. Default is 'table'.
+(string) The format in which to return the output. Options are: table, json, csv. Default is 'table'.
 
 ``json``
 ^^^^^^^^
 
-  Return output in JSON.
+Return output in JSON.
 
-  Given::
+Given::
 
-      rack servers instance list
-      ID	        Name		Status	Public IPv4	Private IPv4	Image	Flavor
-      GUID	my_server	ACTIVE	101.130.19.31	10.208.128.233	GUID	io1-30
+    rack servers instance list
+    ID	        Name		Status	Public IPv4	Private IPv4	Image	Flavor
+    GUID	my_server	ACTIVE	101.130.19.31	10.208.128.233	GUID	io1-30
 
-  Adding the ``--output json`` flag returns::
+Adding the ``--output json`` flag returns::
 
     rack servers instance list --output json
     [
@@ -50,114 +50,114 @@ Options
       }
     ]
 
-  When the output pipe is **not** a tty, the JSON is no longer "pretty printed" and
-  can be used when passing straight into other commands that require a JSON_
-  payload.
+When the output pipe is **not** a tty, the JSON is no longer "pretty printed" and
+can be used when passing straight into other commands that require a JSON_
+payload.
 
 ``table``
 ^^^^^^^^^
 
-  Return output in tabular format. Default output format for ``rack``.
+Return output in tabular format. Default output format for ``rack``.
 
-  Given::
+Given::
 
-      rack servers instance list
-      ID	        Name		Status	Public IPv4	Private IPv4	Image	Flavor
-      GUID	my_server	ACTIVE	101.130.19.31	10.208.128.233	GUID	io1-30
+    rack servers instance list
+    ID	        Name		Status	Public IPv4	Private IPv4	Image	Flavor
+    GUID	my_server	ACTIVE	101.130.19.31	10.208.128.233	GUID	io1-30
 
-  This presents a well formatted table with headers.
+This presents a well formatted table with headers.
 
-  You can add the ``--output table`` option if you have set defaults to JSON,
-  CSV, and so on elsewhere. You can use the ``--no-header`` option to output
-  without headers.
+You can add the ``--output table`` option if you have set defaults to JSON,
+CSV, and so on elsewhere. You can use the ``--no-header`` option to output
+without headers.
 
 ``csv``
 ^^^^^^^
 
-  Return output in csv format.
+Return output in csv format.
 
-  CSV, or comma separated output is useful for passing to other operating system
-  tools, importing into Excel, Google Sheets, or another data tool.
+CSV, or comma separated output is useful for passing to other operating system
+tools, importing into Excel, Google Sheets, or another data tool.
 
-  Given::
+Given::
 
-      rack servers instance list
-      ID	        Name		Status	Public IPv4	Private IPv4	Image	Flavor
-      GUID	my_server	ACTIVE	101.130.19.31	10.208.128.233	GUID	io1-30
+  rack servers instance list
+  ID	        Name		Status	Public IPv4	Private IPv4	Image	Flavor
+  GUID	my_server	ACTIVE	101.130.19.31	10.208.128.233	GUID	io1-30
 
-  Adding the ``--output csv`` option::
+Adding the ``--output csv`` option::
 
-      rack servers instance list --output csv
-      ID,Name,Status,Public IPv4,Private IPv4,Image,Flavor
-      GUID,my_server,ACTIVE,101.130.19.31,10.208.128.233,GUID,io1-30
+  rack servers instance list --output csv
+  ID,Name,Status,Public IPv4,Private IPv4,Image,Flavor
+  GUID,my_server,ACTIVE,101.130.19.31,10.208.128.233,GUID,io1-30
 
-  This presents a compact format with appropriate CSV headers.
+This presents a compact format with appropriate CSV headers.
 
 ``--log``
 ~~~~~~~~~
 
-  (string) Log relevant information about the HTTP request. Options are: info, debug.
+(string) Log relevant information about the HTTP request. Options are: info, debug.
 
-  Example: ``rack servers keypair list --log info``
+Example: ``rack servers keypair list --log info``
 
 ``--username``
 ~~~~~~~~~~~~~~
 
-  (string) The Rackspace username to use for authentication.
+(string) The Rackspace username to use for authentication.
 
 ``--api-key``
 ~~~~~~~~~~~~~
 
-  (string) The Rackspace API key to use for authentication.
+(string) The Rackspace API key to use for authentication.
 
 ``--auth-tenant-id``
 ~~~~~~~~~~~~~~~~~~~~
 
-  (string) The tenant ID to use for authentication. May only be provided as a command-line flag.
-  (Prefixed with 'auth-' so as to not collide with the ``tenant-id``` command flags.)
+(string) The tenant ID to use for authentication. May only be provided as a command-line flag.
+(Prefixed with 'auth-' so as to not collide with the ``tenant-id``` command flags.)
 
 ``--auth-token``
 ~~~~~~~~~~~~~~~~
 
-  (string) The token to use for authentication. May only be provided as a command-line flag.
-  Must be used with the ``auth-tenant-id`` flag.
+(string) The token to use for authentication. May only be provided as a command-line flag.
+Must be used with the ``auth-tenant-id`` flag.
 
 ``--region``
 ~~~~~~~~~~~~
 
-  (string) The Rackspace region to use for authentication.
+(string) The Rackspace region to use for authentication.
 
 ``--auth-url``
 ~~~~~~~~~~~~~~
 
-  (string) The Rackspace URL to use for authentication. If not provided, this
-  will default to the public U.S. Rackspace endpoint.
+(string) The Rackspace URL to use for authentication. If not provided, this
+will default to the public U.S. Rackspace endpoint.
 
 ``--profile``
 ~~~~~~~~~~~~~
 
-  (string) The name of the profile (in the config file) to use to look for authentication credentials.
+(string) The name of the profile (in the config file) to use to look for authentication credentials.
 
 ``--no-cache``
 ~~~~~~~~~~~~~~
 
-  (boolean) Don't get or set authentication credentials in the rack cache.
+(boolean) Don't get or set authentication credentials in the rack cache.
 
 ``--no-header``
 ~~~~~~~~~~~~~~~
 
-  (boolean) Don't set the header for CSV nor tabular output. Helpful if piping output from a ``list`` command.
+(boolean) Don't set the header for CSV nor tabular output. Helpful if piping output from a ``list`` command.
 
 ``--use-service-net``
 ~~~~~~~~~~~~~~~~~~~~~
 
-  (boolean) Use the Rackspace internal URL to execute the request. This will only be useful when running a
-  ``rack`` command from a Rackspace server.
+(boolean) Use the Rackspace internal URL to execute the request. This will only be useful when running a
+``rack`` command from a Rackspace server.
 
 ``--help, -h``
 ~~~~~~~~~~~~~~
 
-  (boolean) Show help in a given context.
+(boolean) Show help in a given context.
 
 Help is available on the base level; for example::
 
@@ -201,7 +201,7 @@ And it is available per command::
        help, h	Shows a list of commands or help for one command
 
 
-And again, per subcommand:
+And again, per subcommand::
 
     rack servers keypair --help
     NAME:

--- a/docs/services/blockstorage.rst
+++ b/docs/services/blockstorage.rst
@@ -1,6 +1,6 @@
 .. _block_storage:
 
-block-storage
+Block Storage
 =============
 
 Commands for Rackspace Cloud Block Storage.
@@ -18,7 +18,7 @@ Commands
 ``volume``
 ~~~~~~~~~~
 
-  Block Storage Volume operations
+Block Storage Volume operations
 
 ``list``
 ^^^^^^^^
@@ -58,7 +58,7 @@ Usage::
 ``snapshot``
 ~~~~~~~~~~~~
 
-  Block Storage Snapshot operations
+Block Storage Snapshot operations
 
 ``list``
 ^^^^^^^^

--- a/docs/services/examples/block.rst
+++ b/docs/services/examples/block.rst
@@ -1,7 +1,7 @@
 .. _blockexamples
 
 ============================
-Cloud Block Storage examples
+Block Storage
 ============================
 
 Before you get started, be sure you have entered your username and API key
@@ -69,4 +69,3 @@ you wish the snapshot be. In the example, a snapshot called "Store1" is created:
     SnapshotID
     Attachments
     CreatedAt	2015-07-31T18:57:34.652136
-

--- a/docs/services/examples/files.rst
+++ b/docs/services/examples/files.rst
@@ -1,7 +1,7 @@
 .. _cloudfilesexamples:
 
 ====================
-Cloud Files examples
+Files
 ====================
 
 Before you get started on any examples, be sure you have entered your
@@ -13,7 +13,7 @@ Search for existing objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you have a lot of objects, the `rack` command lets you search through
-the list. 
+the list.
 
 First, list the available containers in your account::
 
@@ -60,4 +60,3 @@ First, make sure you have a container to upload to::
 Next, upload a file, in this case a screenshot::
 
     rack files object upload --container screenshots --file browser-screenshot.png --name browser-screenshot.png
-

--- a/docs/services/examples/index.rst
+++ b/docs/services/examples/index.rst
@@ -1,0 +1,24 @@
+Examples
+========
+
+.. toctree::
+   :maxdepth: 3
+   :hidden:
+
+   files.rst
+   servers.rst
+   block.rst
+   networks.rst
+
+Examples for services
+---------------------
+
+This section shows service-specific use cases for Rackspace CLI.
+
+.. toctree::
+  :maxdepth: 2
+
+  files.rst
+  servers.rst
+  block.rst
+  networks.rst

--- a/docs/services/examples/networks.rst
+++ b/docs/services/examples/networks.rst
@@ -1,7 +1,7 @@
 .. _networkexamples:
 
 =======================
-Cloud Networks Examples
+Networks
 =======================
 
 Before you get started, be sure you have entered your username and API key

--- a/docs/services/examples/servers.rst
+++ b/docs/services/examples/servers.rst
@@ -1,7 +1,7 @@
 .. _serversexamples:
 
 ======================
-Cloud Servers examples
+Servers
 ======================
 
 Before you get started on any examples, be sure you have entered your
@@ -37,7 +37,7 @@ Search for existing servers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you have a lot of servers, the `rack` command lets you search through
-the list. 
+the list.
 
 Use grep to search through the list of available Cloud Servers running in your
 account::
@@ -178,32 +178,29 @@ enable simpler migration when a server fails, or a storage volume that remains
 intact even after a server is shutdown or deleted.
 
 To create a bootable volume from an image and launch an instance from
-this volume, use the ``--block-device`` parameter.
+this volume, use the ``--block-device`` parameter::
 
-   The settings are:
+  --block-device "source-type=SOURCE,source-id=ID,destination-type=DEST,volume-size=SIZE,shutdown=PRESERVE,bootindex=INDEX"
 
-   -  ``--block-device``
-      source=SOURCE,id=ID,dest=DEST,size=SIZE,shutdown=PRESERVE,bootindex=INDEX
+- ``source-type=SOURCE``
+  The type of object used to create the block device. Valid values
+  are ``volume``, ``snapshot``, ``image``, and ``blank``.
 
-         **source-type=SOURCE**
-             The type of object used to create the block device. Valid values
-             are ``volume``, ``snapshot``, ``image``, and ``blank``.
+- ``source-id=ID``
+  The ID of the source. Use a volume ID if the ``source-type`` is
+  a volume and an image ID if the ``source-type`` is image.
 
-         **source-id=ID**
-             The ID of the source. Use a volume ID if the ``source-type`` is
-             a volume and an image ID if the ``source-type`` is image.
+- ``destination-type=DEST``
+  The type of the target virtual device. Valid values are ``volume``
+  and ``local``.
 
-         **destination-type=DEST**
-             The type of the target virtual device. Valid values are ``volume``
-             and ``local``.
+- ``volume-size=SIZE``
+  The size of the volume that is created in GB.
 
-         **volume-size=SIZE**
-             The size of the volume that is created in GB.
-
-         **delete-on-termination={true\|false}**
-             What to do with the volume when the instance is deleted. Use
-             ``false`` to delete the volume and ``true`` to delete the
-             volume when the instance is deleted.
+- ``delete-on-termination={true\|false}``
+  What to do with the volume when the instance is deleted. Use
+  ``false`` to delete the volume and ``true`` to delete the
+  volume when the instance is deleted.
 
 Use this command to boot from a volume::
 

--- a/docs/services/files.rst
+++ b/docs/services/files.rst
@@ -164,7 +164,7 @@ Deletes one or more metadata keys from an object::
 
 
 ``account``
-~~~~~~~~~~
+~~~~~~~~~~~
 
 Cloud Files account commands use this syntax::
 
@@ -194,4 +194,3 @@ metadata if there is no current metadata associated with the account::
 Deletes one or more metadata keys from an account::
 
     rack files account delete-metadata  --metadata-keys <key1,key2,...> [optional flags]
-

--- a/docs/services/index.rst
+++ b/docs/services/index.rst
@@ -3,10 +3,19 @@
 Services
 ========
 
+.. toctree::
+   :maxdepth: 3
+   :hidden:
+
+   servers.rst
+   files.rst
+   blockstorage.rst
+   networks.rst
+   examples/index.rst
+
+
 Here you can find the services currently supported by Rackspace CLI, and those
 services' supported commands.
-
-.. _cmd-reference:
 
 Commands Reference
 ------------------
@@ -31,10 +40,10 @@ This section shows service-specific use cases for Rackspace CLI.
 .. toctree::
    :maxdepth: 2
 
-   cloudfilesexamples.rst
-   cloudserversexamples.rst
-   cloudblockexamples.rst
-   cloudnetworksexamples.rst
+   examples/files
+   examples/servers
+   examples/block
+   examples/networks
 
 .. _authenticating:
 


### PR DESCRIPTION
This PR slightly modifies the structure of the documentation in order to make the nav usable in the current two-column layout. It also removes all (assumed inadvertent) uses of the `<blockquote>` element and fixes several `<pre>` blocks that weren't formatted correctly.