### PR TITLE
format output of volume actions

### DIFF
--- a/commands/blockstoragecommands/snapshotcommands/create.go
+++ b/commands/blockstoragecommands/snapshotcommands/create.go
@@ -36,7 +36,7 @@ func flagsCreate() []cli.Flag {
 	}
 }
 
-var keysCreate = []string{"ID", "Name", "Description", "Size", "VolumeType", "SnapshotID", "Attachments", "CreatedAt", "Metadata"}
+var keysCreate = []string{"ID", "Name", "Description", "Size", "VolumeID", "VolumeType", "SnapshotID", "Attachments", "CreatedAt", "Metadata"}
 
 type paramsCreate struct {
 	opts *osSnapshots.CreateOpts

--- a/commands/blockstoragecommands/snapshotcommands/create.go
+++ b/commands/blockstoragecommands/snapshotcommands/create.go
@@ -36,7 +36,7 @@ func flagsCreate() []cli.Flag {
 	}
 }
 
-var keysCreate = []string{"ID", "Name", "Description", "Size", "VolumeType", "SnapshotID", "Attachments", "CreatedAt"}
+var keysCreate = []string{"ID", "Name", "Description", "Size", "VolumeType", "SnapshotID", "Attachments", "CreatedAt", "Metadata"}
 
 type paramsCreate struct {
 	opts *osSnapshots.CreateOpts
@@ -94,4 +94,12 @@ func (command *commandCreate) Execute(resource *handler.Resource) {
 		return
 	}
 	resource.Result = snapshotSingle(snapshot)
+}
+
+func (command *commandCreate) PreCSV(resource *handler.Resource) {
+	resource.FlattenMap("Metadata")
+}
+
+func (command *commandCreate) PreTable(resource *handler.Resource) {
+	command.PreCSV(resource)
 }

--- a/commands/blockstoragecommands/snapshotcommands/create_test.go
+++ b/commands/blockstoragecommands/snapshotcommands/create_test.go
@@ -1,0 +1,1 @@
+package snapshotcommands

--- a/commands/blockstoragecommands/snapshotcommands/get.go
+++ b/commands/blockstoragecommands/snapshotcommands/get.go
@@ -36,7 +36,7 @@ func flagsGet() []cli.Flag {
 	}
 }
 
-var keysGet = []string{"ID", "Name", "Size", "Status", "VolumeID", "VolumeType", "SnapshotID", "Bootable", "Attachments"}
+var keysGet = []string{"ID", "Name", "Size", "Status", "VolumeID", "VolumeType", "SnapshotID", "Bootable", "Attachments", "Metadata"}
 
 type paramsGet struct {
 	snapshotID string
@@ -96,4 +96,12 @@ func (command *commandGet) Execute(resource *handler.Resource) {
 
 func (command *commandGet) StdinField() string {
 	return "id"
+}
+
+func (command *commandGet) PreCSV(resource *handler.Resource) {
+	resource.FlattenMap("Metadata")
+}
+
+func (command *commandGet) PreTable(resource *handler.Resource) {
+	command.PreCSV(resource)
 }

--- a/commands/blockstoragecommands/snapshotcommands/list.go
+++ b/commands/blockstoragecommands/snapshotcommands/list.go
@@ -37,7 +37,7 @@ func flagsList() []cli.Flag {
 	}
 }
 
-var keysList = []string{"ID", "Name", "Size", "Status", "VolumeID", "VolumeType", "SnapshotID", "Bootable", "Attachments"}
+var keysList = []string{"ID", "Name", "Size", "Status", "VolumeID", "VolumeType", "SnapshotID", "Bootable"}
 
 type paramsList struct {
 	opts *osSnapshots.ListOpts

--- a/commands/blockstoragecommands/volumecommands/create.go
+++ b/commands/blockstoragecommands/volumecommands/create.go
@@ -40,7 +40,7 @@ func flagsCreate() []cli.Flag {
 	}
 }
 
-var keysCreate = []string{"ID", "Name", "Description", "Size", "VolumeType", "SnapshotID", "Attachments", "CreatedAt"}
+var keysCreate = []string{"ID", "Name", "Description", "Size", "VolumeType", "SnapshotID", "Attachments", "CreatedAt", "Metadata"}
 
 type paramsCreate struct {
 	opts *osVolumes.CreateOpts
@@ -99,4 +99,13 @@ func (command *commandCreate) Execute(resource *handler.Resource) {
 		return
 	}
 	resource.Result = volumeSingle(volume)
+}
+
+func (command *commandCreate) PreCSV(resource *handler.Resource) {
+	resource.FlattenMap("Metadata")
+	resource.FlattenMap("Attachments")
+}
+
+func (command *commandCreate) PreTable(resource *handler.Resource) {
+	command.PreCSV(resource)
 }

--- a/commands/blockstoragecommands/volumecommands/get.go
+++ b/commands/blockstoragecommands/volumecommands/get.go
@@ -36,7 +36,7 @@ func flagsGet() []cli.Flag {
 	}
 }
 
-var keysGet = []string{"ID", "Name", "Description", "Size", "VolumeType", "SnapshotID", "Attachments", "CreatedAt"}
+var keysGet = []string{"ID", "Name", "Bootable", "Description", "Size", "VolumeType", "SnapshotID", "SourceVolID", "Attachments", "CreatedAt", "Metadata"}
 
 type paramsGet struct {
 	volumeID string
@@ -96,4 +96,13 @@ func (command *commandGet) Execute(resource *handler.Resource) {
 
 func (command *commandGet) StdinField() string {
 	return "id"
+}
+
+func (command *commandGet) PreCSV(resource *handler.Resource) {
+	resource.FlattenMap("Metadata")
+	resource.FlattenMap("Attachments")
+}
+
+func (command *commandGet) PreTable(resource *handler.Resource) {
+	command.PreCSV(resource)
 }

--- a/commands/blockstoragecommands/volumecommands/list.go
+++ b/commands/blockstoragecommands/volumecommands/list.go
@@ -33,7 +33,7 @@ func flagsList() []cli.Flag {
 	}
 }
 
-var keysList = []string{"ID", "Name", "Size", "Status", "Description", "VolumeType", "SnapshotID", "Attachments", "Created"}
+var keysList = []string{"ID", "Name", "Bootable", "Size", "Status", "VolumeType", "SnapshotID"}
 
 type paramsList struct {
 	opts *osVolumes.ListOpts

--- a/commands/blockstoragecommands/volumecommands/update.go
+++ b/commands/blockstoragecommands/volumecommands/update.go
@@ -101,3 +101,11 @@ func (command *commandUpdate) Execute(resource *handler.Resource) {
 	}
 	resource.Result = volumeSingle(volume)
 }
+
+func (command *commandUpdate) PreCSV(resource *handler.Resource) {
+	resource.FlattenMap("Attachments")
+}
+
+func (command *commandUpdate) PreTable(resource *handler.Resource) {
+	command.PreCSV(resource)
+}

--- a/handler/resource.go
+++ b/handler/resource.go
@@ -27,6 +27,14 @@ func (resource *Resource) FlattenMap(key string) {
 	res := resource.Result.(map[string]interface{})
 	if m, ok := res[key]; ok && util.Contains(keys, key) {
 		switch m.(type) {
+		case []map[string]interface{}:
+			for i, hashmap := range m.([]map[string]interface{}) {
+				for k, v := range hashmap {
+					newKey := fmt.Sprintf("%s%d:%s", key, i, k)
+					res[newKey] = v
+					keys = append(keys, newKey)
+				}
+			}
 		case map[string]interface{}:
 			for k, v := range m.(map[string]interface{}) {
 				newKey := fmt.Sprintf("%s:%s", key, k)


### PR DESCRIPTION
Specifically, this formats the `Attachments` field, which is an array of hashmaps.