### PR TITLE
Fixed typo on configuration page. Changed order of examples index to match 

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -10,7 +10,7 @@ Installation and Configuration
 Installation
 ------------
 
-The Rackspace CLI ``rack`` is a self-contained binary writted in go_. This means
+The Rackspace CLI ``rack`` is a self-contained binary written in go_. This means
 that installation is as simple as downloading the relevant binary for your
 operating system and ensuring it is on your path.
 

--- a/docs/services/examples/index.rst
+++ b/docs/services/examples/index.rst
@@ -5,8 +5,8 @@ Examples
    :maxdepth: 3
    :hidden:
 
-   files.rst
    servers.rst
+   files.rst
    block.rst
    networks.rst
 
@@ -18,7 +18,7 @@ This section shows service-specific use cases for Rackspace CLI.
 .. toctree::
   :maxdepth: 2
 
-  files.rst
   servers.rst
+  files.rst
   block.rst
   networks.rst

--- a/docs/services/index.rst
+++ b/docs/services/index.rst
@@ -40,8 +40,7 @@ This section shows service-specific use cases for Rackspace CLI.
 .. toctree::
    :maxdepth: 2
 
-   examples/files
    examples/servers
+   examples/files
    examples/block
    examples/networks
-


### PR DESCRIPTION
..the command reference index.  