### PR TITLE
Removing RTD from rack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ install:
 script:
   - if [[ $GIMME_OS == "linux" && $GIMME_ARCH == "amd64" ]]; then GOARCH=$GIMME_ARCH GOOS=$GIMME_OS go test github.com/rackspace/rack/commands/... -v; fi
 before_deploy:
-- curl -X POST http://readthedocs.org/build/rackspace-cli
 - "./script/prep-travis-release.sh"
 - cd build
 deploy:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ ID		9818861f-2f14-437f-89b0-a36dfa1831b7
 AdminPass	4vLb2PiqUGdP
 ```
 
-For complete documentation, see [the docs](http://rackspace-cli.readthedocs.org/en/latest/).
+For complete documentation, see [the docs](https://developer.rackspace.com/docs/rack-cli/).
 
 ## Warning
 


### PR DESCRIPTION
This PR will remove the setup to publish our docs to RTD as part of the CI process.