### PR TITLE
Modularize build scripts, set version and commit via ldflags

### DIFF
--- a/script/build
+++ b/script/build
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source $SCRIPT_DIR/lib.sh
+
 build() {
   if [ -n "$GOPATH" ]; then
     echo "Building rack!"
@@ -7,6 +10,9 @@ build() {
     if [ -z "$RACKBUILD" ]; then
         RACKBUILD=$GOPATH/bin/rack
     fi
+
+    get_commit
+    get_version
 
     COMMIT=$(git rev-parse --verify HEAD)
     LDFLAGS="-X github.com/rackspace/rack/util.Commit=${COMMIT} \

--- a/script/build
+++ b/script/build
@@ -12,7 +12,6 @@ build() {
     get_commit
     get_version
 
-    COMMIT=$(git rev-parse --verify HEAD)
     LDFLAGS="-X github.com/rackspace/rack/util.Commit=${COMMIT} \
              -X github.com/rackspace/rack/util.Version=${VERSION}"
     go build  -ldflags "${LDFLAGS}" -o "${RACKBUILD}"

--- a/script/build
+++ b/script/build
@@ -1,10 +1,22 @@
 #!/bin/bash
 
-if [ -n "$GOPATH" ]; then
-  echo "Building rack!"
-  COMMIT=$(git rev-parse --verify HEAD)
-  echo $COMMIT
-  go build -o $GOPATH/bin/rack -ldflags "-X util.Commit=${COMMIT}"
-else
-  echo '$GOPATH must be defined. Do you have go setup?'
-fi
+build() {
+  if [ -n "$GOPATH" ]; then
+    echo "Building rack!"
+
+    if [ -z "$RACKBUILD" ]; then
+        RACKBUILD=$GOPATH/bin/rack
+    fi
+
+    COMMIT=$(git rev-parse --verify HEAD)
+    LDFLAGS="-X github.com/rackspace/rack/util.Commit=${COMMIT} \
+             -X github.com/rackspace/rack/util.Version=${VERSION}"
+    go build  -ldflags "$LDFLAGS" -o $RACKBUILD
+    return $?
+  else
+    echo '$GOPATH must be defined. Do you have go setup?'
+    return 1
+  fi
+}
+
+build

--- a/script/build
+++ b/script/build
@@ -7,9 +7,7 @@ source "${SCRIPT_DIR}/lib.sh"
 build() {
   if [ -n "$GOPATH" ]; then
     echo "Building rack!"
-
-    # Default build location is $GOPATH/bin/rack
-    : "${RACKBUILD:=$GOPATH/bin/rack}"
+    RACKBUILD=${1:-${GOPATH}/bin/rack}
 
     get_commit
     get_version
@@ -25,4 +23,4 @@ build() {
   fi
 }
 
-build
+build $1

--- a/script/build
+++ b/script/build
@@ -1,7 +1,8 @@
 #!/bin/bash
 
+# Load our library functions
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source $SCRIPT_DIR/lib.sh
+source "${SCRIPT_DIR}/lib.sh"
 
 build() {
   if [ -n "$GOPATH" ]; then
@@ -17,10 +18,10 @@ build() {
     COMMIT=$(git rev-parse --verify HEAD)
     LDFLAGS="-X github.com/rackspace/rack/util.Commit=${COMMIT} \
              -X github.com/rackspace/rack/util.Version=${VERSION}"
-    go build  -ldflags "$LDFLAGS" -o $RACKBUILD
+    go build  -ldflags "${LDFLAGS}" -o "${RACKBUILD}"
     return $?
   else
-    echo '$GOPATH must be defined. Do you have go setup?'
+    echo "\$GOPATH must be defined. Do you have go setup?"
     return 1
   fi
 }

--- a/script/build
+++ b/script/build
@@ -8,9 +8,8 @@ build() {
   if [ -n "$GOPATH" ]; then
     echo "Building rack!"
 
-    if [ -z "$RACKBUILD" ]; then
-        RACKBUILD=$GOPATH/bin/rack
-    fi
+    # Default build location is $GOPATH/bin/rack
+    : "${RACKBUILD:=$GOPATH/bin/rack}"
 
     get_commit
     get_version

--- a/script/build
+++ b/script/build
@@ -23,4 +23,4 @@ build() {
   fi
 }
 
-build $1
+build "$1"

--- a/script/build
+++ b/script/build
@@ -3,8 +3,8 @@
 if [ -n "$GOPATH" ]; then
   echo "Building rack!"
   COMMIT=$(git rev-parse --verify HEAD)
-  echo -e "package util\n\nvar Commit = \"$COMMIT\"" > util/commit.go
-  go build -o $GOPATH/bin/rack
+  echo $COMMIT
+  go build -o $GOPATH/bin/rack -ldflags "-X util.Commit=${COMMIT}"
 else
   echo '$GOPATH must be defined. Do you have go setup?'
 fi

--- a/script/lib.sh
+++ b/script/lib.sh
@@ -9,6 +9,8 @@ get_branch() {
     BRANCH=$TRAVIS_BRANCH
   fi
   export BRANCH
+  
+  return 0
 }
 
 get_commit() {

--- a/script/lib.sh
+++ b/script/lib.sh
@@ -3,13 +3,13 @@
 get_branch() {
   # See http://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
   # for details about default Travis Environment Variables and their values
-  if [ -z "$TRAVIS_BRANCH" ]; then
+  if [ -z "${TRAVIS_BRANCH-}" ]; then
     BRANCH=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
   else
-    BRANCH=$TRAVIS_BRANCH
+    BRANCH=${TRAVIS_BRANCH}
   fi
   export BRANCH
-  
+
   return 0
 }
 
@@ -21,7 +21,7 @@ get_commit() {
 }
 
 get_version() {
-  if [ -z "$TRAVIS_TAG" ]; then
+  if [ -z "${TRAVIS_TAG-}" ]; then
       # Version will be the most recent tag, appended with -dev (e.g. 1.0.0-dev)
       OLD_TAG=$(git describe --tags 2> /dev/null)
 
@@ -29,12 +29,12 @@ get_version() {
 
       # If an old tag wasn't found, set it to dev.
       # Note: the egg came before the chicken
-      if [ "$OLD_TAG" == "" ]; then
+      if [ "${OLD_TAG}" == "" ]; then
           VERSION="dev"
       fi
   else
       # We have ourselves a *real* release
-      VERSION=$TRAVIS_TAG
+      VERSION=${TRAVIS_TAG}
   fi
   export VERSION
 

--- a/script/lib.sh
+++ b/script/lib.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# This script is intended to be `source`d
+
+# It populates several environment variables via these functions:
+# $BRANCH - get_branch()
+# $VERSION - get_version()
+# $COMMIT - get_commit()
+
 get_branch() {
   # See http://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
   # for details about default Travis Environment Variables and their values

--- a/script/lib.sh
+++ b/script/lib.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 get_branch() {
   # See http://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
   # for details about default Travis Environment Variables and their values
@@ -6,18 +8,25 @@ get_branch() {
   else
     BRANCH=$TRAVIS_BRANCH
   fi
+  export BRANCH
 }
 
 get_commit() {
   COMMIT=$(git rev-parse --verify HEAD)
-  return $?
+  RETURN_CODE=$?
+  export COMMIT
+  return $RETURN_CODE
 }
 
 get_version() {
   if [ -z "$TRAVIS_TAG" ]; then
       # Version will be the most recent tag, appended with -dev (e.g. 1.0.0-dev)
       OLD_TAG=$(git describe --tags 2> /dev/null)
+
       VERSION="${OLD_TAG}-dev"
+
+      # If an old tag wasn't found, set it to dev.
+      # Note: the egg came before the chicken
       if [ "$OLD_TAG" == "" ]; then
           VERSION="dev"
       fi
@@ -25,6 +34,7 @@ get_version() {
       # We have ourselves a *real* release
       VERSION=$TRAVIS_TAG
   fi
+  export VERSION
 
   return 0
 }

--- a/script/lib.sh
+++ b/script/lib.sh
@@ -1,0 +1,30 @@
+get_branch() {
+  # See http://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
+  # for details about default Travis Environment Variables and their values
+  if [ -z "$TRAVIS_BRANCH" ]; then
+    BRANCH=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
+  else
+    BRANCH=$TRAVIS_BRANCH
+  fi
+}
+
+get_commit() {
+  COMMIT=$(git rev-parse --verify HEAD)
+  return $?
+}
+
+get_version() {
+  if [ -z "$TRAVIS_TAG" ]; then
+      # Version will be the most recent tag, appended with -dev (e.g. 1.0.0-dev)
+      OLD_TAG=$(git describe --tags 2> /dev/null)
+      VERSION="${OLD_TAG}-dev"
+      if [ "$OLD_TAG" == "" ]; then
+          VERSION="dev"
+      fi
+  else
+      # We have ourselves a *real* release
+      VERSION=$TRAVIS_TAG
+  fi
+
+  return 0
+}

--- a/script/prep-travis-release.sh
+++ b/script/prep-travis-release.sh
@@ -16,7 +16,7 @@ declare -xr BUILDDIR="build"
 
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-source $SCRIPT_DIR/lib.sh
+source "${SCRIPT_DIR}/lib.sh"
 
 ################################################################################
 # Disable strict temporarily to accept global environment variables that come
@@ -82,9 +82,9 @@ BASEDIR="${VERSION}/${os}/${arch}"
 # Mirror the github layout for branches, tags, commits
 TREEDIR="${os}/${arch}/tree"
 
-mkdir -p $BUILDDIR
-mkdir -p $BUILDDIR/$BASEDIR
-mkdir -p $BUILDDIR/$TREEDIR
+mkdir -p "${BUILDDIR}"
+mkdir -p "${BUILDDIR}/${BASEDIR}"
+mkdir -p "${BUILDDIR}/${TREEDIR}"
 
 BASENAME="rack"
 
@@ -94,13 +94,13 @@ RACKBUILD="${BASENAME}${SUFFIX}"
 script/build
 
 # Ship /tree/rack-branchname
-cp $RACKBUILD ${BUILDDIR}/${TREEDIR}/${BASENAME}-${BRANCH}${SUFFIX}
+cp "${RACKBUILD}" "${BUILDDIR}/${TREEDIR}/${BASENAME}-${BRANCH}${SUFFIX}"
 echo "Fresh build for branch '${BRANCH}' at "
 echo "${CDN}/${TREEDIR}/${BASENAME}-${BRANCH}${SUFFIX}"
 
 if [ -n "$TRAVIS_TAG" ]; then
   # Only when we're on an official tag do we spit out the official ones.
-  cp $RACKBUILD ${BUILDDIR}/${BASEDIR}/${BASENAME}${SUFFIX}
+  cp "${RACKBUILD}" "${BUILDDIR}/${BASEDIR}/${BASENAME}${SUFFIX}"
   echo "Get it while it's hot at"
   echo "${CDN}/${BASEDIR}/${BASENAME}${SUFFIX}"
 fi

--- a/script/prep-travis-release.sh
+++ b/script/prep-travis-release.sh
@@ -89,9 +89,13 @@ mkdir -p "${BUILDDIR}/${TREEDIR}"
 BASENAME="rack"
 
 # Base build not in build dir to prevent accidental upload on failure
-RACKBUILD="${BASENAME}${SUFFIX}"
-
+export RACKBUILD="${BASENAME}${SUFFIX}"
 script/build
+
+if (( $? != 0 )); then
+  echo "Failed build."
+  return 1
+fi
 
 # Ship /tree/rack-branchname
 cp "${RACKBUILD}" "${BUILDDIR}/${TREEDIR}/${BASENAME}-${BRANCH}${SUFFIX}"

--- a/script/prep-travis-release.sh
+++ b/script/prep-travis-release.sh
@@ -72,6 +72,8 @@ build() {
 }
 
 deploy() {
+  # Set up the directory structure for release to rack's backing CDN
+  # and copy the built `rack` into the right paths for this build type
 
   BASEDIR="${VERSION}/${os}/${arch}"
   # Mirror the github layout for branches, tags, commits

--- a/script/prep-travis-release.sh
+++ b/script/prep-travis-release.sh
@@ -29,10 +29,6 @@ if [[ -z "${GIMME_OS-}" && -z "${GIMME_ARCH-}" ]]; then
   exit 2
 fi
 
-set +u
-
-
-
 os=$GIMME_OS
 arch=$GIMME_ARCH
 
@@ -41,12 +37,10 @@ get_version
 get_commit
 
 # Ensure GOARM is defined later
-if [ "$arch" == "arm" -a -z "$GOARM" ]; then
+if [ "$arch" == "arm" -a -z "${GOARM-}" ]; then
   GOARM="6"
 fi
 
-# Back to strict
-set -u
 ################################################################################
 
 case $os in

--- a/script/prep-travis-release.sh
+++ b/script/prep-travis-release.sh
@@ -13,105 +13,101 @@ IFS=$'\n\t'
 
 declare -xr CDN="https://ec4a542dbf90c03b9f75-b342aba65414ad802720b41e8159cf45.ssl.cf5.rackcdn.com"
 declare -xr BUILDDIR="build"
+declare -xr BASENAME="rack"
 
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-
 source "${SCRIPT_DIR}/lib.sh"
 
-
-################################################################################
-# Disable strict temporarily to accept global environment variables that come
-# from GIMME and Travis
-################################################################################
-
-if [[ -z "${GIMME_OS-}" && -z "${GIMME_ARCH-}" ]]; then
-  >&2 echo "GIMME_OS and GIMME_ARCH must be defined"
-  exit 2
-fi
-
-os=$GIMME_OS
-arch=$GIMME_ARCH
-
-get_branch
-get_version
-get_commit
-
-# Ensure GOARM is defined later
-if [ "$arch" == "arm" -a -z "${GOARM-}" ]; then
-  GOARM="6"
-fi
-
-################################################################################
-
-case $os in
-  windows)
-    os="Windows"
-    ;;
-  linux)
-    os="Linux"
-    ;;
-  darwin)
-    os="Darwin"
-    ;;
-  freebsd)
-    os="FreeBSD"
-    ;;
-  *)
-    >&2 echo "Unknown OS ${os}. Assuming it's a valid OS for gimme/go and charging ahead."
-esac
-
-case $arch in
-  arm)
-    # Note that we can never be 1:1 between `uname -m` and arm versions
-    arch="armv${GOARM}"
-    ;;
-esac
-
-SUFFIX=""
-if [ "$os" == "Windows" ]; then
-  SUFFIX=".exe"
-fi
-
-################################################################################
-# Set up the build and deploy layout
-################################################################################
-
-BASEDIR="${VERSION}/${os}/${arch}"
-# Mirror the github layout for branches, tags, commits
-TREEDIR="${os}/${arch}/tree"
-
-mkdir -p "${BUILDDIR}"
-mkdir -p "${BUILDDIR}/${BASEDIR}"
-mkdir -p "${BUILDDIR}/${TREEDIR}"
-
-BASENAME="rack"
-
-# Base build not in build dir to prevent accidental upload on failure
-export RACKBUILD="${BASENAME}${SUFFIX}"
-script/build
-
-if (( $? != 0 )); then
-  echo "Failed build."
-  return 1
-fi
-
-# Ship /tree/rack-branchname
-cp "${RACKBUILD}" "${BUILDDIR}/${TREEDIR}/${BASENAME}-${BRANCH}${SUFFIX}"
-
-# Only when we're on the canonical rackspace/rack repo will we be shipping
-# binaries, which comes down to whether TRAVIS_SECURE_ENV_VARS is defined
-if [ -n "${TRAVIS_SECURE_ENV_VARS-}" ]; then
-  echo "Fresh build for branch '${BRANCH}' at "
-  echo "${CDN}/${TREEDIR}/${BASENAME}-${BRANCH}${SUFFIX}"
-  if [ -n "${TRAVIS_TAG-}" ]; then
-    # Only when we're on an official tag do we spit out the official ones.
-    cp "${RACKBUILD}" "${BUILDDIR}/${BASEDIR}/${BASENAME}${SUFFIX}"
-    echo "Get it while it's hot at"
-    echo "${CDN}/${BASEDIR}/${BASENAME}${SUFFIX}"
+initialize() {
+  if [[ -z "${GIMME_OS-}" && -z "${GIMME_ARCH-}" ]]; then
+    >&2 echo "GIMME_OS and GIMME_ARCH must be defined"
+    exit 2
   fi
-  # Clean up after build
-  rm $RACKBUILD
-else
-  # Do nothing, keep the built artifact
-  echo "${RACKBUILD} is ready for you"
-fi
+
+  os=$GIMME_OS
+  arch=$GIMME_ARCH
+
+  get_branch
+  get_version
+  get_commit
+
+  # Ensure GOARM is defined later
+  if [ "$arch" == "arm" -a -z "${GOARM-}" ]; then
+    GOARM="6"
+  fi
+
+  case $os in
+    windows)
+      os="Windows"
+      ;;
+    linux)
+      os="Linux"
+      ;;
+    darwin)
+      os="Darwin"
+      ;;
+    freebsd)
+      os="FreeBSD"
+      ;;
+    *)
+      >&2 echo "Unknown OS ${os}. Assuming it's a valid OS for gimme/go and charging ahead."
+  esac
+
+  case $arch in
+    arm)
+      # Note that we can never be 1:1 between `uname -m` and arm versions
+      arch="armv${GOARM}"
+      ;;
+  esac
+
+  SUFFIX=""
+  if [ "$os" == "Windows" ]; then
+    SUFFIX=".exe"
+  fi
+}
+
+build() {
+  RACKBUILD="${BASENAME}${SUFFIX}"
+  script/build ${RACKBUILD}
+}
+
+deploy() {
+
+  BASEDIR="${VERSION}/${os}/${arch}"
+  # Mirror the github layout for branches, tags, commits
+  TREEDIR="${os}/${arch}/tree"
+
+  mkdir -p "${BUILDDIR}"
+  mkdir -p "${BUILDDIR}/${BASEDIR}"
+  mkdir -p "${BUILDDIR}/${TREEDIR}"
+
+  if (( $? != 0 )); then
+    echo "Failed build."
+    exit 1
+  fi
+
+  # Ship /tree/rack-branchname
+  cp "${RACKBUILD}" "${BUILDDIR}/${TREEDIR}/${BASENAME}-${BRANCH}${SUFFIX}"
+
+  # Only when we're on the canonical rackspace/rack repo will we be shipping
+  # binaries, which comes down to whether TRAVIS_SECURE_ENV_VARS is defined
+  if [ -n "${TRAVIS_SECURE_ENV_VARS-}" ]; then
+    echo "Fresh build for branch '${BRANCH}' at "
+    echo "${CDN}/${TREEDIR}/${BASENAME}-${BRANCH}${SUFFIX}"
+    if [ -n "${TRAVIS_TAG-}" ]; then
+      # Only when we're on an official tag do we spit out the official ones.
+      cp "${RACKBUILD}" "${BUILDDIR}/${BASEDIR}/${BASENAME}${SUFFIX}"
+      echo "Get it while it's hot at"
+      echo "${CDN}/${BASEDIR}/${BASENAME}${SUFFIX}"
+    fi
+    # Clean up after build
+    rm $RACKBUILD
+  else
+    # Do nothing, keep the built artifact
+    echo "${RACKBUILD} is ready for you"
+  fi
+}
+
+initialize
+build
+deploy

--- a/script/publish-docs
+++ b/script/publish-docs
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-ROOT=$(cd $(dirname $0)/.. && pwd)
+ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 TARGET=${1:-staging}
 
@@ -31,8 +31,8 @@ esac
 echo "Submitting metadata envelopes to ${CONTENT_STORE_URL}."
 
 exec docker run --rm \
-  -e CONTENT_STORE_URL=${CONTENT_STORE_URL} \
-  -e CONTENT_STORE_APIKEY=${CONTENT_STORE_APIKEY} \
+  -e CONTENT_STORE_URL="${CONTENT_STORE_URL}" \
+  -e CONTENT_STORE_APIKEY="${CONTENT_STORE_APIKEY}" \
   -e TRAVIS_PULL_REQUEST="false" \
-  -v ${ROOT}/docs:/usr/content-repo \
+  -v "${ROOT}/docs:/usr/content-repo" \
   quay.io/deconst/preparer-sphinx

--- a/script/release
+++ b/script/release
@@ -7,18 +7,17 @@ set -euo pipefail
 
 function update {
   TMP_FILE=$(mktemp -d 2>/dev/null || mktemp -d -t "$1")
-  sed -e "$2" $3 > $TMP_FILE
-  chmod 0644 $TMP_FILE
-  mv -f $TMP_FILE $3
+  sed -e "$2" "$3" > "$TMP_FILE"
+  chmod 0644 "$TMP_FILE"
+  mv -f "$TMP_FILE" "$3"
 }
 
 NEW_VERSION=${1:-}
 REMOTE="release"
 REMOTE_URL="git@github.com:rackspace/rack.git"
-VERSION_FILE="util/util.go"
 DOCS_INDEX_FILE="docs/index.rst"
 DOCS_CONFIGURATION_FILE="docs/configuration.rst"
-BRANCH=`git rev-parse --abbrev-ref HEAD`
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 echo "Releasing new version: ${NEW_VERSION}"
 
@@ -48,9 +47,9 @@ fi
 # Now confirm that we've got the proper remote URL
 #
 
-REMOTE_ACTUAL_URL=`git remote show release | grep Push | cut -d ":" -f2-`
+REMOTE_ACTUAL_URL=$(git remote show release | grep Push | cut -d ":" -f2-)
 
-if [ $REMOTE_URL != $REMOTE_ACTUAL_URL ]; then
+if [ "$REMOTE_URL" != "$REMOTE_ACTUAL_URL" ]; then
   echo -e "Remote \"${REMOTE}\" PUSH url incorrect.\nShould be ${REMOTE_URL}. Exiting."
   exit 3
 fi
@@ -60,7 +59,7 @@ fi
 #
 
 set +e
-WORKSPACE_STATUS=`git diff --exit-code`
+git diff --exit-code | /dev/null
 if [ $? != 0 ]; then
   echo "Workspace is not clean. Exiting"
   exit 4
@@ -72,18 +71,12 @@ set -e
 #
 
 git fetch $REMOTE
-SYNC_STATUS=`git rev-list master...${REMOTE}/master`
+SYNC_STATUS=$(git rev-list master...${REMOTE}/master)
 
 if [ -n "$SYNC_STATUS" ]; then
   echo "Master is not in sync with release remote. Exiting."
   exit 5
 fi
-
-#
-# Generate new util.go with proper version
-#
-
-update ./util.go-version "s/var Version =.*/var Version = \"$NEW_VERSION\"/" $VERSION_FILE
 
 #
 # Update the docs index paths
@@ -102,7 +95,7 @@ update ./configuration.rst-version "s#rackcdn\.com/[0-9a-zA-Z.-]*/#rackcdn\.com/
 #
 
 git commit -am "Version ${NEW_VERSION}"
-git tag ${NEW_VERSION}
+git tag "${NEW_VERSION}"
 git push ${REMOTE} master
 git push ${REMOTE} --tags
 

--- a/util/commit.go
+++ b/util/commit.go
@@ -1,3 +1,0 @@
-package util
-
-var Commit = "3e8a69d7938e660e2f00179e31193a35979f9ac3"

--- a/util/util.go
+++ b/util/util.go
@@ -78,5 +78,10 @@ func Pluralize(noun string, count int64) string {
 	return noun
 }
 
+// The following are both set during build time
+
 // Version is the current CLI version
-var Version = "1.0.0-beta.1"
+var Version string
+
+// Commit is the commit this build comes from
+var Commit string


### PR DESCRIPTION
The build scripts are now standardized with a library script for getting the version, commit, and branch. Using this, I've set up `util.Commit` and `util.Version` to get set via `-ldflags -X github.com/rackspace/rack/util.Commit=$COMMIT` so it's at build time instead of *every single time we build*.

This is also setup in a way that you can run:

```bash
./script/prep-travis-release.sh
```

locally, which will output to `./rack`. Running

```bash
./script/build
```

still results in output to `$GOPATH/bin/rack`. You can specify where you want the built binary to end up by adding an argument to `./script/build` like so:

```bash
./script/build ~/myrack # outputs to ~/myrack
```

If you build the binary like normal, it still results in a built binary (but with no version or commit information):

```bash
$ go build && ./rack version
rack version
commit:
```

That doesn't break anything for folks (yay!), but won't be as misleading as it would have been before (stale commit and version).