### PR TITLE
Concurrent dlo

### DIFF
--- a/auth/clients.go
+++ b/auth/clients.go
@@ -324,6 +324,12 @@ func newHTTPClient() http.Client {
 
 // RoundTrip performs a round-trip HTTP request and logs relevant information about it.
 func (lrt *LogRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	defer func() {
+		if request.Body != nil {
+			request.Body.Close()
+		}
+	}()
+
 	var err error
 
 	if lrt.Logger.Level == logrus.DebugLevel && request.Body != nil {

--- a/commands/filescommands/largeobjectcommands/upload.go
+++ b/commands/filescommands/largeobjectcommands/upload.go
@@ -66,6 +66,10 @@ func flagsUpload() []cli.Flag {
 				Usage: "[optional] A comma-separated string of key=value pairs.",
 			},
 		*/
+		cli.IntFlag{
+			Name:  "concurrency",
+			Usage: "[optional] The number of workers that will be uploading pieces at the same time.",
+		},
 	}
 }
 
@@ -119,7 +123,8 @@ func (command *commandUpload) HandleFlags(resource *handler.Resource) error {
 			ContentLength: int64(c.Int("content-length")),
 			ContentType:   c.String("content-type"),
 		},
-		SizePieces: int64(c.Int("size-pieces")),
+		SizePieces:  int64(c.Int("size-pieces")),
+		Concurrency: c.Int("concurrency"),
 	}
 
 	/*

--- a/internal/github.com/rackspace/gophercloud/provider_client.go
+++ b/internal/github.com/rackspace/gophercloud/provider_client.go
@@ -210,7 +210,7 @@ func (client *ProviderClient) Request(method, url string, options RequestOpts) (
 					}
 				}
 				if options.RawBody != nil {
-					seeker, ok := options.RawBody.(io.ReadSeeker)
+					seeker, ok := options.RawBody.(io.Seeker)
 					if !ok {
 						return nil, &ErrErrorSeekingAfterReauthentication{
 							BaseError: BaseError{


### PR DESCRIPTION
This PR allows users to specify how many concurrent uploads to have. Currently `rack` will requeue an upload that stalls or fails 10 times before giving up. That may be another flag we should provide (number of times to retry a failed upload for each piece).