### PR TITLE
Add toctree link to index page

### DIFF
--- a/docs/_toc.rst
+++ b/docs/_toc.rst
@@ -2,6 +2,7 @@
    :maxdepth: 99
    :includehidden:
 
+   Rackspace CLI <https://developer.rackspace.com/docs/rack-cli/>
    configuration.rst
    globaloptions.rst
    services/index.rst


### PR DESCRIPTION
This follows a pattern we use in other docs to add the title of the entire document as the first link in the toctree.

![image](https://cloud.githubusercontent.com/assets/3018940/15184711/ef2f66fc-175b-11e6-818d-e7f9c742a126.png)
