### PR TITLE
fix out of memory problems while downloading described in #441

### DIFF
--- a/script/build
+++ b/script/build
@@ -14,10 +14,10 @@ build() {
     get_version
 
     # Check the go version
-    EQ=" "
-    go version | grep -q go1.5
-    if [ $? == 0 ]; then
-      EQ="="
+    EQ="="
+    regex="(go[0-1].[0-4])"
+    if [[ `go version` =~ $regex ]]; then
+        EQ=" "
     fi
 
     LDFLAGS="-X github.com/rackspace/rack/util.Commit${EQ}${COMMIT} \


### PR DESCRIPTION
avoid reading `resp.Body` in `logResponseBody` if `contentType` not contains  *"application/json"*

fix building failure when go verision > 1.5