### PR TITLE
Move chocolatey packaging build to appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,10 @@
+version: '{build}'
+skip_non_tags: true
+environment:
+  APPVEYOR_CHOCOLATEY_PASSWORD:
+    secure: TPt2VhWIlCR2q5P61E/VJTO3OSLb+t1JAj9lq2qNNoUjiRFRYRrJfxOAFcHqLaZc
+before_build:
+- ps: sleep 300
+build:
+  project: script/chocolatey/build.proj
+  verbosity: normal

--- a/script/chocolatey/build.proj
+++ b/script/chocolatey/build.proj
@@ -7,8 +7,8 @@
   </Target>
 
   <Target Name="Publish" DependsOnTargets="Package">
-    <!-- The environment variable BAMBOO_CHOCOLATEY_PASSWORD comes from the chocolatey.password variable defined on the rack plan in Bamboo -->
-    <Exec Command="choco push rack.$(NuGetVersion).nupkg --api-key %25BAMBOO_CHOCOLATEY_PASSWORD%25" />
+    <!-- The environment variable APPVEYOR_CHOCOLATEY_PASSWORD comes from the chocolatey.password variable defined on the rack plan in AppVeyor -->
+    <Exec Command="choco push rack.$(NuGetVersion).nupkg --api-key %25APPVEYOR_CHOCOLATEY_PASSWORD%25" />
   </Target>
 
   <Target Name="Package">


### PR DESCRIPTION
This moves the Chocolatey packaging build from http://build.openstacknetsdk.org/browse/RAX-CLI to AppVeyor.

* Wait 5 minutes before attempting to pull down the exe generated by the travis build.
* Only publish to Chocolately if the package hasn't already been published.
* Publish under the `rackspace` Chocolatey user account.