### PR TITLE
Fix typos

### DIFF
--- a/commands/networkscommands/subnetcommands/create.go
+++ b/commands/networkscommands/subnetcommands/create.go
@@ -56,7 +56,7 @@ func flagsCreate() []cli.Flag {
 			Name: "allocation-pool",
 			Usage: strings.Join([]string{"[optional] An allocation pool for this subnet. This flag may be provided several times.\n",
 				"\tEach one of these flags takes 2 values: start and end.\n",
-				"\tExamle: --allocation-pool start=192.0.2.1,end=192.0.2.254 --allocation-pool start:172.20.0.1,end=172.20.0.254"}, ""),
+				"\tExample: --allocation-pool start=192.0.2.1,end=192.0.2.254 --allocation-pool start:172.20.0.1,end=172.20.0.254"}, ""),
 		},
 		cli.StringFlag{
 			Name:  "dns-nameservers",
@@ -67,7 +67,7 @@ func flagsCreate() []cli.Flag {
 				Name: "host-route",
 				Usage: strings.Join([]string{"[optional] A host route for this subnet. This flag may be provided several times.\n",
 					"\tEach one of these flags takes 2 values: dest (the destination CIDR) and next (the next hop).\n",
-					"\tExamle: --host-route dest=40.0.1.0/24,next=40.0.0.2"}, ""),
+					"\tExample: --host-route dest=40.0.1.0/24,next=40.0.0.2"}, ""),
 			},
 		*/
 	}

--- a/commands/networkscommands/subnetcommands/update.go
+++ b/commands/networkscommands/subnetcommands/update.go
@@ -55,7 +55,7 @@ func flagsUpdate() []cli.Flag {
 				Name: "host-route",
 				Usage: strings.Join([]string{"[optional] A host route for this subnet. This flag may be provided several times.\n",
 					"\tEach one of these flags takes 2 values: dest (the destination CIDR) and next (the next hop).\n",
-					"\tExamle: --host-route dest=40.0.1.0/24,next=40.0.0.2"}, ""),
+					"\tExample: --host-route dest=40.0.1.0/24,next=40.0.0.2"}, ""),
 			},
 		*/
 	}

--- a/commands/serverscommands/instancecommands/create.go
+++ b/commands/serverscommands/instancecommands/create.go
@@ -98,7 +98,7 @@ func flagsCreate() []cli.Flag {
 				"\t\tdelete-on-termination\t[optional] Whether or not to delete the attached volume when the server is delete. Default is false. Options: true, false.",
 				"\t\tdestination-type\t[optional] The type that gets created. Options: volume, local.",
 				"\t\tvolume-size\t[optional] The size of the volume to create (in gigabytes).",
-				"\tExamle: --block-device source-type=image,source-id=bb02b1a3-bc77-4d17-ab5b-421d89850fca,volume-size=100,destination-type=volume,delete-on-termination=false",
+				"\tExample: --block-device source-type=image,source-id=bb02b1a3-bc77-4d17-ab5b-421d89850fca,volume-size=100,destination-type=volume,delete-on-termination=false",
 			}, "\n"),
 		},
 		cli.BoolFlag{

--- a/docs/services/servers.rst
+++ b/docs/services/servers.rst
@@ -260,7 +260,7 @@ Image
 
 The ``image`` subcommand provides information about server images. The ``image`` subcommand uses the following syntax::
 
-    rack server image <action> [optional flags]
+    rack servers image <action> [optional flags]
 
 The following sections describe the actions that you can perform on the ``image`` subcommand and provide example responses.
 
@@ -512,7 +512,7 @@ The ``volume-attachment`` subcommand provides information about and performs act
 
 The ``volume-attachment`` subcommand uses the following syntax::
 
-    rack server volume-attachment <action> [optional flag]
+    rack servers volume-attachment <action> [optional flag]
 
 The following sections describe the actions that you can perform on the ``volume-attachment`` subcommand and provide example responses.
 


### PR DESCRIPTION
I noticed the [docs](https://developer.rackspace.com/docs/rack-cli/services/servers/) for the `rack servers` command includes two incorrect example commands, and the help text for a couple of commands has a typo.

This PR fixes those.